### PR TITLE
Capitalize Perl according to the Perl style guide.

### DIFF
--- a/srfi-135.html
+++ b/srfi-135.html
@@ -1794,8 +1794,8 @@ by <code>text-unfold</code> to be limited by limits on stack size.
   </p>
 <pre class="code-example">
 (textual-replace "The TCL programmer endured daily ridicule."
-                 "another miserable perl drone" 4 7 8 22)
-    =&gt; «The miserable perl programmer endured daily ridicule.»
+                 "another miserable Perl drone" 4 7 8 22)
+    =&gt; «The miserable Perl programmer endured daily ridicule.»
 
 (textual-replace "It's easy to code it up in Scheme." "lots of fun" 5 9)
     =&gt; «It's lots of fun to code it up in Scheme.»


### PR DESCRIPTION
The style guide:

https://www.perl.org/about/style-guide.html